### PR TITLE
ci: disable Codecov for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,14 @@ jobs:
       - name: Type check (mypy)
         run: uv run mypy
 
-      - name: Tests (pytest + coverage)
-        run: uv run pytest --cov-report=xml
+      - name: Tests (pytest)
+        run: uv run pytest
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.5.4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          fail_ci_if_error: false
+      # Codecov upload disabled for now. To re-enable, restore this step and add
+      # the CODECOV_TOKEN repository secret:
+      #   - name: Upload coverage to Codecov
+      #     uses: codecov/codecov-action@v5.5.4
+      #     with:
+      #       token: ${{ secrets.CODECOV_TOKEN }}
+      #       files: ./coverage.xml
+      #       fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Joint Service Deployment - Manager Placement
 
 [![CI](https://github.com/reinnet/jsd-mp/actions/workflows/ci.yml/badge.svg)](https://github.com/reinnet/jsd-mp/actions/workflows/ci.yml)
-[![Codecov](https://img.shields.io/codecov/c/gh/reinnet/jsd-mp?logo=codecov&style=flat-square)](https://codecov.io/gh/reinnet/jsd-mp)
 
 
 ## Introduction


### PR DESCRIPTION
Removes the Codecov upload step from CI (kept commented for easy re-enable once `CODECOV_TOKEN` is set) and drops the dead coverage badge. Coverage is still computed via pytest addopts; it just isn't uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)