### PR TITLE
test: track the dropped tests/config/test_load.py

### DIFF
--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -1,0 +1,38 @@
+from jsd_mp.config import load
+from jsd_mp.domain import Direction
+
+
+def test_laod():
+    cfg = load("config_example")
+
+    assert "ingress" in cfg.types
+    assert cfg.types["ingress"].memory == 0
+    assert cfg.types["ingress"].cores == 0
+    assert cfg.types["ingress"].direction == Direction.INGRESS
+    assert not cfg.types["ingress"].manageable
+
+    assert len(cfg.chains) == 1
+    assert cfg.chains[0].fee == 181
+    assert cfg.chains[0].functions == [
+        cfg.types["ingress"],
+        cfg.types["vDPI"],
+        cfg.types["vDPI"],
+        cfg.types["vNAT"],
+        cfg.types["egress"],
+    ]
+
+    assert cfg.vnfm.memory == 4
+    assert cfg.vnfm.cores == 2
+    assert cfg.vnfm.capacity == 10
+    assert cfg.vnfm.radius == 100
+    assert cfg.vnfm.bandwidth == 1
+    assert cfg.vnfm.license_cost == 100
+
+    assert "switch-15" in cfg.topology.nodes
+    assert "server-1" in cfg.topology.nodes
+    assert cfg.topology.nodes["server-1"].cores == 20
+    assert cfg.topology.nodes["server-1"].memory == 100
+    assert cfg.topology.nodes["server-1"].vnf_support
+    assert cfg.topology.nodes["switch-9"].direction == Direction.BOTH
+    assert "server-3" in cfg.topology.nodes["server-1"].not_manager_nodes
+    assert "switch-12" in cfg.topology.connections["server-1"]


### PR DESCRIPTION
`tests/config/test_load.py` was matched by the old unanchored `config/` gitignore rule (same root cause as the `src/jsd_mp/config` package fix), so it was never committed and CI silently ran without it. The rule is already anchored to `/config/`; this adds the missing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)